### PR TITLE
Refactor error handling, caching, and option defaults

### DIFF
--- a/lib/airtable_snapshot.ex
+++ b/lib/airtable_snapshot.ex
@@ -1,44 +1,23 @@
 defmodule AirtableSnapshot do
-  def fetch(
-        opts = %{
-          key: key,
-          table: table,
-          base: base,
-          filter_records: filter_records,
-          process_records: process_records
-        }
-      )
+  require Logger
+
+  def fetch(%{key: key, table: table, base: base} = opts)
       when is_binary(key) and is_binary(table) and is_binary(base) do
+    filter_records = Map.get(opts, :filter_records, fn _ -> true end)
+    process_records = Map.get(opts, :process_records, & &1)
     bucket_name = Map.get(opts, :bucket_name, "dialer-airtable-snapshots")
 
-    try do
-      filtered_and_processed =
-        fresh_fetch(%{
-          key: key,
-          table: table,
-          base: base,
-          filter_records: filter_records,
-          process_records: process_records
-        })
-
-      store_snapshot(filtered_and_processed, %{
-        table: table,
-        base: base,
-        bucket_name: bucket_name
-      })
-
-      filtered_and_processed
-    rescue
-      _error ->
-        fetch_latest_snapshot(%{
-          table: table,
-          base: base,
-          bucket_name: bucket_name
-        })
-    end
+    fetch_records(%{
+      key: key,
+      table: table,
+      base: base,
+      filter_records: filter_records,
+      process_records: process_records,
+      bucket_name: bucket_name
+    })
   end
 
-  def fresh_fetch(
+  def fetch_records(
         opts = %{
           key: key,
           table: table,
@@ -64,24 +43,39 @@ defmodule AirtableSnapshot do
     case body do
       %{"offset" => next_offset, "records" => records} ->
         accumulated_records = Enum.concat(prev_records, records)
-        fresh_fetch(opts, accumulated_records, next_offset)
+        fetch_records(opts, accumulated_records, next_offset)
 
       %{"records" => records} ->
-        Enum.concat(prev_records, records)
-        |> (fn rs -> filter_records.(rs) end).()
-        |> (fn rs -> process_records.(rs) end).()
+        prev_records
+        |> Enum.concat(records)
+        |> filter_records.()
+        |> process_records.()
+        |> cache_snapshot(opts)
     end
+  rescue
+    error ->
+      Logger.error("""
+      Failed to fetch from Airtable key=#{key} table=#{table} base=#{base}
+      #{inspect(error)}
+      Falling back to S3 cache.
+      """)
+
+      fetch_latest_snapshot(opts)
   end
 
-  def store_snapshot(contents, opts = %{bucket_name: bucket_name}) do
-    timestamp = DateTime.utc_now() |> DateTime.to_unix()
-    postfix = "#{9_999_999_999 - timestamp}"
-    object_name = "#{format_name_prefix(opts)}-#{postfix}"
+  defp cache_snapshot(contents, opts = %{bucket_name: bucket_name}) do
+    spawn(fn ->
+      timestamp = DateTime.utc_now() |> DateTime.to_unix()
+      postfix = "#{9_999_999_999 - timestamp}"
+      object_name = "#{format_name_prefix(opts)}-#{postfix}"
 
-    binary_contents = Jason.encode!(contents)
+      binary_contents = Jason.encode!(contents)
 
-    ExAws.S3.put_object(bucket_name, object_name, binary_contents)
-    |> ExAws.request!()
+      ExAws.S3.put_object(bucket_name, object_name, binary_contents)
+      |> ExAws.request!()
+    end)
+
+    contents
   end
 
   def fetch_latest_snapshot(opts = %{bucket_name: bucket_name}) do


### PR DESCRIPTION
### What does do?

1. filter_records and process_records both have no-op defaults (and so are no longer required
2. failures storing to s3 will no longer cause failure in returning fresh results
3. logs when there's an error fetching from airtable

**nb** there aren't a whole lotta tests in here, so test in dev to make sure all's well eh

