### PR TITLE
Remove AWS caching + dependency. Remove filter/process records options

### DIFF
--- a/lib/airtable_snapshot.ex
+++ b/lib/airtable_snapshot.ex
@@ -3,31 +3,30 @@ defmodule AirtableSnapshot do
 
   def fetch(%{key: key, table: table, base: base} = opts)
       when is_binary(key) and is_binary(table) and is_binary(base) do
-    filter_records = Map.get(opts, :filter_records, fn _ -> true end)
-    process_records = Map.get(opts, :process_records, & &1)
+    if Map.has_key?(opts, :filter_records) or Map.has_key?(opts, :process_records) do
+      raise """
+      `:filter_records` and `:process_records` options have been removed.
+      use Enum.map/2, Enum.filter/2 on the results of this function instead.
+      """
+    end
+
     bucket_name = Map.get(opts, :bucket_name, "dialer-airtable-snapshots")
 
     fetch_records(%{
       key: key,
       table: table,
       base: base,
-      filter_records: filter_records,
-      process_records: process_records,
       bucket_name: bucket_name
     })
   end
 
-  def fetch_records(
-        opts = %{
-          key: key,
-          table: table,
-          base: base,
-          filter_records: filter_records,
-          process_records: process_records
-        },
-        prev_records \\ [],
-        offset \\ 0
-      ) do
+  defp fetch_records(opts, prev_records \\ [], offset \\ 0) do
+    %{
+      key: key,
+      table: table,
+      base: base
+    } = opts
+
     %{body: raw_body} =
       HTTPotion.get(
         "https://api.airtable.com/v0/#{base}/#{URI.encode(table)}",
@@ -46,58 +45,13 @@ defmodule AirtableSnapshot do
         fetch_records(opts, accumulated_records, next_offset)
 
       %{"records" => records} ->
-        prev_records
-        |> Enum.concat(records)
-        |> filter_records.()
-        |> process_records.()
-        |> cache_snapshot(opts)
+        Enum.concat(prev_records, records)
     end
   rescue
     error ->
       Logger.error("""
       Failed to fetch from Airtable key=#{key} table=#{table} base=#{base}
       #{inspect(error)}
-      Falling back to S3 cache.
       """)
-
-      fetch_latest_snapshot(opts)
-  end
-
-  defp cache_snapshot(contents, opts = %{bucket_name: bucket_name}) do
-    spawn(fn ->
-      timestamp = DateTime.utc_now() |> DateTime.to_unix()
-      postfix = "#{9_999_999_999 - timestamp}"
-      object_name = "#{format_name_prefix(opts)}-#{postfix}"
-
-      binary_contents = Jason.encode!(contents)
-
-      ExAws.S3.put_object(bucket_name, object_name, binary_contents)
-      |> ExAws.request!()
-    end)
-
-    contents
-  end
-
-  def fetch_latest_snapshot(opts = %{bucket_name: bucket_name}) do
-    object_stream =
-      ExAws.S3.list_objects(bucket_name, prefix: format_name_prefix(opts))
-      |> ExAws.stream!()
-
-    case object_stream |> Enum.take(1) do
-      [%{key: latest_key}] ->
-        %{body: body} =
-          ExAws.S3.get_object(bucket_name, latest_key)
-          |> ExAws.request!()
-
-        Poison.decode!(body)
-
-      [] ->
-        :error_on_missing_cache
-    end
-  end
-
-  def format_name_prefix(%{table: table, base: base}) do
-    slugified_table = table |> String.downcase() |> String.replace(" ", "_", global: true)
-    "#{slugified_table}@#{base}"
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AirtableSnapshot.MixProject do
   def project do
     [
       app: :airtable_snapshot,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps()
@@ -21,15 +21,10 @@ defmodule AirtableSnapshot.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
       {:httpotion, "~> 3.1.0"},
       {:jason, "~> 1.1"},
-      {:ex_aws, "~> 2.0"},
-      {:ex_aws_s3, "~> 2.0"},
       {:poison, "~> 3.0"},
-      {:hackney, "~> 1.9"},
-      {:sweet_xml, "~> 0.6"}
+      {:hackney, "~> 1.9"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,5 @@
 %{
   "certifi": {:hex, :certifi, "2.4.2", "75424ff0f3baaccfd34b1214184b6ef616d89e420b258bb0a5ea7d7bc628f7f0", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
-  "ex_aws": {:hex, :ex_aws, "2.1.0", "b92651527d6c09c479f9013caa9c7331f19cba38a650590d82ebf2c6c16a1d8a", [:mix], [{:configparser_ex, "~> 2.0", [hex: :configparser_ex, repo: "hexpm", optional: true]}, {:hackney, "1.6.3 or 1.6.5 or 1.7.1 or 1.8.6 or ~> 1.9", [hex: :hackney, repo: "hexpm", optional: true]}, {:jsx, "~> 2.8", [hex: :jsx, repo: "hexpm", optional: true]}, {:poison, ">= 1.2.0", [hex: :poison, repo: "hexpm", optional: true]}, {:sweet_xml, "~> 0.6", [hex: :sweet_xml, repo: "hexpm", optional: true]}, {:xml_builder, "~> 0.1.0", [hex: :xml_builder, repo: "hexpm", optional: true]}], "hexpm"},
-  "ex_aws_s3": {:hex, :ex_aws_s3, "2.0.1", "9e09366e77f25d3d88c5393824e613344631be8db0d1839faca49686e99b6704", [:mix], [{:ex_aws, "~> 2.0", [hex: :ex_aws, repo: "hexpm", optional: false]}, {:sweet_xml, ">= 0.0.0", [hex: :sweet_xml, repo: "hexpm", optional: true]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.14.3", "b5f6f5dcc4f1fba340762738759209e21914516df6be440d85772542d4a5e412", [:rebar3], [{:certifi, "2.4.2", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpotion": {:hex, :httpotion, "3.1.0", "14d20d9b0ce4e86e253eb91e4af79e469ad949f57a5d23c0a51b2f86559f6589", [:mix], [{:ibrowse, "~> 4.4", [hex: :ibrowse, repo: "hexpm", optional: false]}], "hexpm"},
   "ibrowse": {:hex, :ibrowse, "4.4.1", "2b7d0637b0f8b9b4182de4bd0f2e826a4da2c9b04898b6e15659ba921a8d6ec2", [:rebar3], [], "hexpm"},
@@ -12,6 +10,5 @@
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
-  "sweet_xml": {:hex, :sweet_xml, "0.6.5", "dd9cde443212b505d1b5f9758feb2000e66a14d3c449f04c572f3048c66e6697", [:mix], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
This is a breaking change.

### Breaking Changes

- remove support for `filter_records` and `process_records`. will raise if those options are still passed
- does not cache results to s3
- will not fallback to s3 cache if airtable requests fail